### PR TITLE
Use Node.js 18 in update workflow

### DIFF
--- a/.github/workflows/update_repos.yml
+++ b/.github/workflows/update_repos.yml
@@ -14,9 +14,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 18
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
Update workflow runs have been failing since #3.

This PR updates Node.js to version 18, which is required by the [Replicate SDK](https://github.com/replicate/replicate-javascript).